### PR TITLE
feat: add Shopify prelaunch landing section

### DIFF
--- a/assets/prelaunch.css
+++ b/assets/prelaunch.css
@@ -1,0 +1,106 @@
+@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap');
+
+body {
+  margin: 0;
+  background: #000;
+  color: #fff;
+  font-family: 'Bebas Neue', sans-serif;
+  overflow-x: hidden;
+}
+.prelaunch-header {
+  background: #000;
+  padding: 10px 20px;
+}
+.prelaunch-header .logo {
+  height: 40px;
+}
+.prelaunch-hero {
+  position: relative;
+  height: 100vh;
+  background: #f5f5ef;
+}
+.scroll-text {
+  position: absolute;
+  top: 40%;
+  left: 10%;
+  font-size: 2.5rem;
+  color: #000;
+  transition: transform 0.1s ease-out;
+}
+.mascot {
+  position: fixed;
+  top: 15%;
+  right: 10%;
+  width: 30vw;
+  height: 60vh;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  opacity: 0;
+  animation: fadeIn 1.5s forwards;
+}
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.choice-section {
+  padding: 100px 20px;
+  text-align: center;
+}
+.choice-text {
+  font-size: 2rem;
+  margin-bottom: 40px;
+}
+.goats {
+  display: flex;
+  justify-content: center;
+  gap: 40px;
+  margin-bottom: 40px;
+}
+.goat {
+  width: 100px;
+  animation: goat 3s infinite ease-in-out alternate;
+}
+@keyframes goat {
+  from { transform: translateY(0); }
+  to { transform: translateY(-15px); }
+}
+.next-button {
+  padding: 10px 30px;
+  background: #fff;
+  color: #000;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+}
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+.modal.open {
+  display: flex;
+}
+.modal-content {
+  background: #fff;
+  color: #000;
+  padding: 40px;
+  position: relative;
+  text-align: center;
+}
+.modal .close {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}

--- a/assets/prelaunch.js
+++ b/assets/prelaunch.js
@@ -1,0 +1,27 @@
+document.addEventListener('scroll', () => {
+  const text = document.querySelector('.scroll-text');
+  if (text) {
+    text.style.transform = `translateY(${window.scrollY}px)`;
+  }
+});
+
+const emailModal = document.querySelector('.email-modal');
+const thankyouModal = document.querySelector('.thankyou-modal');
+const nextButton = document.querySelector('.next-button');
+const closeButtons = document.querySelectorAll('.modal .close');
+
+nextButton?.addEventListener('click', () => {
+  emailModal?.classList.add('open');
+});
+
+document.getElementById('email-form')?.addEventListener('submit', (e) => {
+  e.preventDefault();
+  emailModal?.classList.remove('open');
+  thankyouModal?.classList.add('open');
+});
+
+closeButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    btn.closest('.modal')?.classList.remove('open');
+  });
+});

--- a/sections/prelaunch-landing.liquid
+++ b/sections/prelaunch-landing.liquid
@@ -1,0 +1,60 @@
+{% comment %}
+  Prelaunch landing section
+{% endcomment %}
+
+{% assign logo = section.settings.logo | default: 'logo-mockup.png' %}
+{% assign mascot = section.settings.mascot | default: 'g-mockup1.png' %}
+
+<div class="prelaunch-header">
+  <img class="logo" src="{{ logo | image_url: width: 200 }}" alt="Logo" />
+</div>
+<section class="prelaunch-hero">
+  <h1 class="scroll-text">You made a choice to change the game.<br/>Embody the act.</h1>
+  <div class="mascot" style="background-image:url({{ mascot | image_url }});"></div>
+</section>
+<section class="choice-section">
+  <h2 class="choice-text">Choice is yours</h2>
+  <div class="goats">
+    <img src="{{ 'goat-left.png' | asset_url }}" alt="Goat left" class="goat" />
+    <img src="{{ 'goat-right.png' | asset_url }}" alt="Goat right" class="goat" />
+  </div>
+  <button class="next-button">Next</button>
+</section>
+<div class="modal email-modal">
+  <div class="modal-content">
+    <button class="close" aria-label="Close">&times;</button>
+    <h3>Join the herd</h3>
+    <form id="email-form">
+      <input type="email" name="email" placeholder="Email" required />
+      <button type="submit">Submit</button>
+    </form>
+  </div>
+</div>
+<div class="modal thankyou-modal">
+  <div class="modal-content">
+    <button class="close" aria-label="Close">&times;</button>
+    <h3>Thank you!</h3>
+    <p>You are now a Founding GOAT.</p>
+  </div>
+</div>
+
+{{ 'prelaunch.css' | asset_url | stylesheet_tag }}
+{{ 'prelaunch.js'  | asset_url | script_tag }}
+
+{% schema %}
+{
+  "name": "Prelaunch landing",
+  "settings": [
+    {
+      "type": "image_picker",
+      "id": "logo",
+      "label": "Logo"
+    },
+    {
+      "type": "image_picker",
+      "id": "mascot",
+      "label": "Mascot"
+    }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary
- create Shopify section for prelaunch landing with mascot, scroll text, and goat animation
- add modal flow for email signup and thank you
- include dedicated stylesheet and script assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68901643f564832f9e91727936c8e624